### PR TITLE
Properly convert list-like queryargs

### DIFF
--- a/client.go
+++ b/client.go
@@ -75,6 +75,12 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...requestOption)
 	return data, nil
 }
 
+func (c *Client) NewGetHealthService() *GetHealthService {
+	return &GetHealthService{
+		c: c,
+	}
+}
+
 func (c *Client) NewGetSubscribersService() *GetSubscribersService {
 	return &GetSubscribersService{
 		c: c,

--- a/health.go
+++ b/health.go
@@ -1,0 +1,32 @@
+package listmonk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type GetHealthService struct {
+	c ClientInterface
+}
+
+func (s *GetHealthService) Do(ctx context.Context, opts ...requestOption) (*bool, error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/health",
+	}
+
+	bytes, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string]bool
+	err = json.Unmarshal(bytes, &res)
+
+	if err != nil {
+		return nil, err
+	}
+	var result bool = res["data"]
+	return &result, nil
+}

--- a/request.go
+++ b/request.go
@@ -39,9 +39,9 @@ func (r *request) setParam(key string, value interface{}) *request {
 	return r
 }
 
-func (r *request) setParamList(baseParam string, params ...interface{}) *request {
-	for index, value := range params {
-		r.setParam(fmt.Sprintf("%s[%d]", baseParam, index), value)
+func (r *request) setParamList(baseParam string, params []uint) *request {
+	for _, value := range params {
+		r.setParam(baseParam, fmt.Sprintf("%d", value))
 	}
 	return r
 }


### PR DESCRIPTION
ithout this change setting the ListId value to [1, 2] yields queryargs like

list_id[0]=[1,2]

What it should be, according to the documentation is

list_id=1&list_id=2

This change does that by forcibly converting each value to a string directly rather than leveraging the JSON marshalling of setParam.